### PR TITLE
fix: reduce docker build image size by over 13x

### DIFF
--- a/resources/Dockerfile
+++ b/resources/Dockerfile
@@ -1,21 +1,12 @@
-# From https://github.com/aws/aws-cdk/blob/95f8cef0505dd2deb8ee5e45ab98c6ab1b764b02/packages/%40aws-cdk/aws-lambda-python-alpha/lib/Dockerfile
-# The correct AWS SAM build image based on the runtime of the function will be
-# passed as build arg. The default allows to do `docker build .` when testing.
-ARG PYTHON_VERSION=3.7
-ARG IMAGE=public.ecr.aws/sam/build-python${PYTHON_VERSION}
-FROM $IMAGE
+# Build arg defaults (allow simple `docker build .` when testing)
+ARG PYTHON_VERSION=3.13
+ARG UV_VERSION
+FROM ghcr.io/astral-sh/uv:${UV_VERSION:+${UV_VERSION}-}python${PYTHON_VERSION}-bookworm-slim
 
-ARG PIP_INDEX_URL
-ARG PIP_EXTRA_INDEX_URL
-ARG HTTPS_PROXY
-ARG UV_VERSION=0.4.20
-
-ENV PIP_CACHE_DIR=/tmp/pip-cache
-ENV UV_CACHE_DIR=/tmp/uv-cache
-
-RUN mkdir /tmp/pip-cache && \
-    chmod -R 777 /tmp/pip-cache && \
-    pip install uv==$UV_VERSION && \
-    rm -rf /tmp/pip-cache/*
+RUN apt-get update && \
+    apt-get install -y rsync && \
+    rm -rf /var/lib/apt/lists/* && \
+    mkdir -p /.cache/uv && \
+    chmod 777 /.cache/uv
 
 CMD [ "python" ]


### PR DESCRIPTION
## Motivation

The current SAM image is unnecessarily large, leaving room for improvement. Below is a comparison of the resulting Docker images before and after the Dockerfile optimization:

![image](https://github.com/user-attachments/assets/e7a682ac-fd7f-4c19-978d-27b5c6dbc464)

## Premise

- **uv** [requires Python 3.8 or later](https://docs.astral.sh/uv/reference/policies/platforms/)  
- AWS Lambda's Python 3.8 runtime is [deprecated](https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html#runtimes-deprecated), and function creation will no longer be possible after Feb 28, 2025.

Given this, Python 3.9 is the minimum viable version. However, setting Python 3.13 as the default makes more sense, allowing users to override the build argument if needed.

## Approach

We'll leverage the official [uv Docker images](https://docs.astral.sh/uv/guides/integration/docker/), which bundle both uv and Python. This eliminates the need to install them manually, enabling seamless selection of any uv and Python version. By default, we'll use the latest uv binary and Python 3.13.

To simplify customization, we could introduce a `uvVersion` property in the `PythonFunction` construct. This would allow users to override the uv version without touching `buildArgs` in the `bundling` property.

## Simplifications

1. Removed all PIP-related environment variables, as [uv ignores them](https://docs.astral.sh/uv/pip/compatibility/#configuration-files-and-environment-variables).  
2. Removed `UV_CACHE_DIR`, defaulting to `$HOME/.cache/uv` instead of setting a custom cache directory.

## Results

These changes reduce the Docker image size from over **2GB** to just **156MB**, while retaining flexibility to select any Python and uv version directly from the base image.
